### PR TITLE
Add support for Zone ID in stops. Change contains_id in fare_rules to be a string

### DIFF
--- a/models.go
+++ b/models.go
@@ -56,6 +56,7 @@ type Stop struct {
 	Longitude   float64 `csv:"stop_lon"`
 	Type        string  `csv:"location_type"`
 	Parent      string  `csv:"parent_station"`
+	ZoneId      string  `csv:"zone_id"`
 }
 
 // StopTime -
@@ -169,7 +170,7 @@ type FareRule struct {
 	RouteID       string `csv:"route_id"`
 	OriginID      string `csv:"origin_id"`
 	DestinationID string `csv:"destination_id"`
-	ContainsID    int    `csv:"contains_id"`
+	ContainsID    string `csv:"contains_id"`
 }
 
 // Pathway -


### PR DESCRIPTION
Fixes compatibility with AC transit gtfs feed